### PR TITLE
fix(vanish-workflow): remove staging and prod from matrix environments

### DIFF
--- a/.github/workflows/vanish.yml
+++ b/.github/workflows/vanish.yml
@@ -16,8 +16,9 @@ permissions:
 jobs:
   scheduled-destroy:
     strategy:
+      
       matrix:
-        environment: ["dev", "staging", "prod"]
+        environment: ["dev"]    # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#handling-failures
     uses: ./.github/workflows/terraform.yml
     with:
       apply: true


### PR DESCRIPTION
matrix job strategy will cancel any concurrent job if one of them fail, since there are no stag and prod environment at the moment, the dev job cannot run